### PR TITLE
Upgrade to Metabase v0.47.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: metabase/metabase
-          ref: v0.46.7
+          ref: v0.47.0
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
           cache: "yarn"
 
       - name: Get M2 cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 * Clojure 1.11+
 * OpenJDK 17
-* Node.js 16.x
+* Node.js 18.x
 * Yarn
 
 For testing: Docker Compose
@@ -24,7 +24,7 @@ The easiest way to set up a development environment is as follows (mostly the sa
 ```bash
 git clone https://github.com/metabase/metabase.git
 cd metabase
-checkout v0.46.7
+checkout v0.47.0
 git clone https://github.com/MaterializeInc/metabase-materialize-driver.git modules/drivers/materialize
 ```
 

--- a/scripts/exclude_tests.diff
+++ b/scripts/exclude_tests.diff
@@ -1,16 +1,3 @@
-diff --git a/test/metabase/query_processor_test.clj b/test/metabase/query_processor_test.clj
-index b26ac03b83..fd5c2abb99 100644
---- a/test/metabase/query_processor_test.clj
-+++ b/test/metabase/query_processor_test.clj
-@@ -365,7 +365,7 @@
-   also have this issue."
-   [driver]
-   ;; TIMEZONE FIXME — remove this and fix the drivers
--  (contains? #{:snowflake :oracle :redshift} driver))
-+  (contains? #{:snowflake :oracle :redshift :materialize} driver))
-
- (defn nest-query
-   "Nest an MBQL/native query by `n-levels`. Useful for testing how nested queries behave."
 diff --git a/test/metabase/query_processor_test/explicit_joins_test.clj b/test/metabase/query_processor_test/explicit_joins_test.clj
 index 166598c4c6..e1bef679f1 100644
 --- a/test/metabase/query_processor_test/explicit_joins_test.clj

--- a/scripts/exclude_tests.diff
+++ b/scripts/exclude_tests.diff
@@ -62,24 +62,3 @@ index 87d225f5ae..343eb1f5f5 100644
                 [["2015-06-01T10:31:00-04:00" 1]
                  ["2015-06-01T16:06:00-04:00" 1]
                  ["2015-06-01T17:23:00-04:00" 1]
-diff --git a/test/metabase/query_processor/middleware/parameters/mbql_test.clj b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
-index cebabc72dc..e148dd5b3f 100644
---- a/test/metabase/query_processor/middleware/parameters/mbql_test.clj
-+++ b/test/metabase/query_processor/middleware/parameters/mbql_test.clj
-@@ -288,6 +288,7 @@
- ;;
- (deftest handle-fk-forms-test
-   (mt/test-drivers (filter #(driver/supports? % :foreign-keys) (params-test-drivers))
-+    (when (not= driver/*driver* :materialize)
-     (testing "Make sure we properly handle paramters that have `fk->` forms in `:dimension` targets (#9017)"
-       (is (= [[31 "Bludso's BBQ" 5 33.8894 -118.207 2]
-               [32 "Boneyard Bistro" 5 34.1477 -118.428 3]
-@@ -317,7 +318,7 @@
-                   {:query      {:order-by [[:asc $id]]}
-                    :parameters [{:type   :string/starts-with
-                                  :target [:dimension $category_id->categories.name]
--                                 :value  ["BB"]}]}))))))))
-+                                 :value  ["BB"]}]})))))))))
-
- (deftest test-mbql-parameters
-   (testing "Should be able to pass parameters in to an MBQL query"

--- a/src/metabase/driver/materialize.clj
+++ b/src/metabase/driver/materialize.clj
@@ -33,6 +33,10 @@
                               :datetime-diff             false
                               :convert-timezone          false
                               :temporal-extract          (not config/is-test?)
+                              ;; Disabling during tests as the data load fails with:
+                              ;; metabase.driver.sql-jdbc.sync.describe-table-test/describe-big-nested-field-columns-test (impl.clj:141)
+                              ;; ERROR: column "big_json" is of type jsonb but expression is of type character varying
+                              :nested-field-columns      (not config/is-test?)
                               ;; Disabling nested queries during tests as they try to use Foreign Keys
                               :nested-queries            (not config/is-test?)
                               ;; Disabling the expressions support due to the following error:

--- a/test/metabase/test/data/materialize.clj
+++ b/test/metabase/test/data/materialize.clj
@@ -86,7 +86,6 @@
 (defmethod load-data/load-data! :materialize [& args]
   (apply load-data/load-data-add-ids-chunked! args))
 
-
 (defmethod tx/sorts-nil-first? :materialize
   [_driver _base-type]
   false)


### PR DESCRIPTION
With Metabase v0.47.0 now available, we have to make sure that the tests are passing again and that the driver is working as expected.

Closes #24 