### PR TITLE
Add release GH workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Metabase Repo
         uses: actions/checkout@v3
@@ -61,7 +63,7 @@ jobs:
       - name: Setup GitHub CLI
         working-directory: modules/drivers/materialize
         run: |
-          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Create Release
         working-directory: modules/drivers/materialize

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,69 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Metabase Repo
+        uses: actions/checkout@v3
+        with:
+          repository: metabase/metabase
+          ref: v0.47.0
+
+      - name: Checkout Driver Repo
+        uses: actions/checkout@v3
+        with:
+          path: modules/drivers/materialize
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Install Clojure CLI
+        run: |
+          curl -O https://download.clojure.org/install/linux-install-1.11.1.1262.sh &&
+          sudo bash ./linux-install-1.11.1.1262.sh
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+          cache: "yarn"
+
+      - name: Get M2 cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2
+            ~/.gitlibs
+          key: ${{ runner.os }}-materialize-${{ hashFiles('**/deps.edn') }}
+
+      - name: Prepare stuff for pulses
+        run: yarn build-static-viz
+
+      - name: Build Materialize driver
+        run: |
+          echo "{:deps {metabase/materialize {:local/root \"materialize\" }}}" > modules/drivers/deps.edn
+          bin/build-driver.sh materialize
+          ls -lah resources/modules
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update -y
+          sudo apt install gh -y
+
+      - name: Setup GitHub CLI
+        working-directory: modules/drivers/materialize
+        run: |
+          gh auth login --with-token <<< "${{ secrets.RELEASE_TOKEN }}"
+
+      - name: Create Release
+        working-directory: modules/drivers/materialize
+        run: |
+          gh release create ${{ github.ref }} ../../../resources/modules/materialize.metabase-driver.jar -t "Release ${{ github.ref }}" -n "Release of the Materialize driver for Metabase"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,12 +2,11 @@ name: Tests
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches:
       - master
     paths-ignore:
       - "**.md"
-  pull_request:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ connect:
 Metabase Release | Driver Version
 ---------------- | --------------
 v0.46.7          | v0.1.0
+v0.47.0          | v0.1.1
 
 ## Contributing
 


### PR DESCRIPTION
Adding a release workflow to build a new jar and create a GH release on tag.

~~We need to create a new GH token and add it as a secret: `secrets.RELEASE_TOKEN` as the default `secrets.GITHUB_TOKENT` does not have the repo privileges to create releases.~~

Totally open to suggestions here!

Closes #23 