### PR TITLE
Update Docker image build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `metabase-materialize-driver` lets
 
 ## To Use the Driver
 
-We provide a pre-built docker image of metabase including this driver as
+We provide a pre-built docker image of Metabase including this driver as
 [materialize/metabase][]
 
 To use the `metabase-materialize-driver` with an existing Metabase
@@ -23,7 +23,7 @@ Once the Materialize driver is registered, use the following information to
 connect:
 
 | Field             | Value                  |
-| ----------------- |:----------------------:|
+| ----------------- | ---------------------- |
 | Database type     | **Materialize**        |
 | Host              | Materialize host name. |
 | Port              | **6875**               |

--- a/bin/build_docker_image.sh
+++ b/bin/build_docker_image.sh
@@ -2,18 +2,20 @@
 
 set -euo pipefail
 
+# Global variables
+METABASE_VERSION=${1:-}
+MATERIALIZE_JAR_PATH=${2:-}
+DOCKER_IMAGE_TAG=${3:-}
+BUILD_DIR=".build"
+
 cleanup() {
     echo "Cleaning up..."
-    rm -f .build/materialize-driver.jar
+    rm -f "${BUILD_DIR}/materialize-driver.jar"
 }
 
 trap cleanup EXIT
 
-METABASE_VERSION=${1:-}
-MATERIALIZE_JAR_PATH=${2:-}
-DOCKER_IMAGE_TAG=${3:-}
-
-if [ -z "$METABASE_VERSION" ] || [ -z "$MATERIALIZE_JAR_PATH" ] || [ -z "$DOCKER_IMAGE_TAG" ]; then
+usage() {
     echo
     echo "Usage: $0 METABASE_VERSION PATH_TO_MATERIALIZE_JAR DOCKER_IMAGE_TAG"
     echo
@@ -21,21 +23,32 @@ if [ -z "$METABASE_VERSION" ] || [ -z "$MATERIALIZE_JAR_PATH" ] || [ -z "$DOCKER
     echo
     echo "Example:"
     echo
-    echo "$0 v0.46.7 /some/path/to/materialize.metabase-driver.jar my-metabase-with-materialize:v0.0.1"
+    echo "$0 v0.47.0 /some/path/to/materialize.metabase-driver.jar my-metabase-with-materialize:v0.0.1"
     exit 1
+}
+
+# Validate input arguments
+if [ -z "$METABASE_VERSION" ] || [ -z "$MATERIALIZE_JAR_PATH" ] || [ -z "$DOCKER_IMAGE_TAG" ]; then
+    usage
 fi
 
+# Validate the JAR file's existence
 if [ ! -f "$MATERIALIZE_JAR_PATH" ]; then
     echo "Error: JAR file '$MATERIALIZE_JAR_PATH' not found!"
     exit 2
 fi
 
-mkdir -p .build
+# Create build directory
+echo "Preparing build environment..."
+mkdir -p "$BUILD_DIR"
 
-cp "$MATERIALIZE_JAR_PATH" .build/materialize-driver.jar
+# Copy JAR to build directory
+cp "$MATERIALIZE_JAR_PATH" "${BUILD_DIR}/materialize-driver.jar"
 
+# Build the Docker image
 echo "Building Docker image with Metabase version '$METABASE_VERSION' and Materialize driver..."
 docker build --build-arg METABASE_VERSION="$METABASE_VERSION" --tag "$DOCKER_IMAGE_TAG" .
 
+# Completion message
 echo "Build complete. Image tagged as '$DOCKER_IMAGE_TAG'."
 echo "To run the image, use 'docker run -p 3000:3000 $DOCKER_IMAGE_TAG'"


### PR DESCRIPTION
The old build.sh script has been removed as we now use the build scripts provided by the Metabase project directly. The new Docker image build script is mainly intended for testing purposes.

Closes #22 