### PR TITLE
Add Github Action Schedules

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,8 @@ on:
       - master
     paths-ignore:
       - "**.md"
+  schedule:
+    - cron: 0 11 * * 0
 
 jobs:
   test:


### PR DESCRIPTION
Add scheduled integration tests to run once a week against the newest `materialize/materialized` image.