### PR TITLE
Add schema filter options

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -30,6 +30,9 @@ driver:
       helper-text: Your Materialize cluster name.
     - user
     - password
+    - name: schema-filters
+      type: schema-filters
+      display-name: Schemas
 init:
   - step: load-namespace
     namespace: metabase.driver.materialize

--- a/src/metabase/driver/materialize.clj
+++ b/src/metabase/driver/materialize.clj
@@ -31,7 +31,7 @@
                               ;; Materialize defaults to UTC, and this is the only supported value
                               :set-timezone              false
                               :datetime-diff             false
-                              :convert-timezone          false
+                              :convert-timezone          (not config/is-test?)
                               :temporal-extract          (not config/is-test?)
                               ;; Disabling during tests as the data load fails with:
                               ;; metabase.driver.sql-jdbc.sync.describe-table-test/describe-big-nested-field-columns-test (impl.clj:141)


### PR DESCRIPTION
Similar to the default Postgres driver, adding schema filter options to the database connection settings.

<img width="693" alt="image" src="https://github.com/MaterializeInc/metabase-materialize-driver/assets/21223421/9fed74ca-366e-4589-ac4c-e09e8a11f0e3">
