### PR TITLE
Set `max_tables` as system parameter

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,6 @@ jobs:
           compose-file: "modules/drivers/materialize/docker-compose.yml"
           services: |
             materialize
-            init
 
       # Apply the scripts/exclude_tests.diff patch to exclude tests that are not relevant to Materialize
       - name: Apply exclude_tests.diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ sudo -- sh -c "echo 127.0.0.1 materialize >> /etc/hosts"
 * Start Materialize as a Docker container
 
 ```bash
-docker compose -f modules/drivers/materialize/docker-compose.yml up -d materialize init
+docker compose -f modules/drivers/materialize/docker-compose.yml up -d materialize
 ```
 
 Now, you should be able to run the tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - --availability-zone=test1
       - --availability-zone=test2
       - --bootstrap-role=materialize
+      - --system-parameter-default=max_tables=1000
     ports:
       - 6875:6875
       - 6877:6877
@@ -19,20 +20,6 @@ services:
         interval: 1s,
         start_period: 35s,
       }
-  init:
-    image: postgres:15.3-alpine3.18
-    depends_on:
-      - materialize
-    command: >-
-      sh -c '
-      echo "Waiting for materialized to start..." &&
-      sleep 15 &&
-      echo "Set Materialize max_tables to 1000" &&
-      psql -h materialize -U mz_system -d materialize -p 6877 -c "ALTER SYSTEM SET max_tables = 1000;" &&
-      psql -h materialize -U materialize -d materialize -p 6875 -c "SHOW max_tables;"
-      '
-    environment:
-      - PGPASSWORD=materialize
 
   metabase:
     image: metabase/metabase:v0.49.12


### PR DESCRIPTION
Removing the init container and setting `max_tables` as a system parameter instead.