### PR TITLE
Disable telemetry in CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - --availability-zone=test2
       - --bootstrap-role=materialize
       - --system-parameter-default=max_tables=1000
+    environment:
+      MZ_NO_TELEMETRY: 1
     ports:
       - 6875:6875
       - 6877:6877


### PR DESCRIPTION
As the Docker image now has telemetry enabled by default, we should disable this in all repos where we use it similar to: https://github.com/MaterializeInc/terraform-provider-materialize/pull/640